### PR TITLE
Fix #5: Remove log message

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -15,13 +15,6 @@ export default class LogKeeperPlugin extends Plugin {
 	settings: LogKeeperSettings
 
 	async onload() {
-		// Logging debugging information on load.
-		console.log(`Activating: ${this.manifest.name}\n
-			 Version: ${this.manifest.version}
-			 Author: ${this.manifest.author}
-			 Author URL: ${this.manifest.authorUrl}`
-			)
-		
 		await this.loadSettings()
 
 		// This adds a settings tab so the user can configure various aspects of the plugin


### PR DESCRIPTION
Close #5: To comply with Obsidian guide against unnecessary logging to the debug terminal, remove logging code.