### PR TITLE
Fixes #8: Edit 'esbuild.config.mjs' 'entryPoint' Variable to Match Dir Structure

### DIFF
--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -15,7 +15,7 @@ const context = await esbuild.context({
 	banner: {
 		js: banner,
 	},
-	entryPoints: ["main.ts"],
+	entryPoints: ["src/main.ts"],
 	bundle: true,
 	external: [
 		"obsidian",


### PR DESCRIPTION
No troubles have been reported as a result of the dir structure change made in commit "eca2dc7", but to be sure, fix the entry point in 'esbuild.config.mjs' to point to the main TS file located in 'src/'.