### PR TITLE
Fix Issue #4 and #7: Update Class Names in 'styles.css' and Remove ':…

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -52,6 +52,7 @@ export class LogKeeperTab extends PluginSettingTab {
 
 		// ONE MODIFICATON PER DAY
 		new Setting(containerEl)
+			.setClass('log-keeper-setting')
 			.setName("Toggle one modification per day")
 			.setDesc(`
 				Toggle between tracking modifications made to notes per day or by the interval set by Update Interval.
@@ -70,6 +71,7 @@ export class LogKeeperTab extends PluginSettingTab {
 
 		// UPDATE INTERVAL
 		new Setting(containerEl)
+			.setClass('log-keeper-setting')
 			.setName('Update interval (in seconds)')
 			.setDesc(`
 					The amount of time between the last modification and the most recent modification before a new value is added
@@ -107,6 +109,7 @@ export class LogKeeperTab extends PluginSettingTab {
 
 		// IGNORED FOLDERS
 		new Setting(containerEl)
+			.setClass('log-keeper-setting')
 			.setName("Ignored folders")
 			.setDesc(`
 				Ignored folders will prevent notes within them from being stamped with a date and time.
@@ -119,16 +122,17 @@ export class LogKeeperTab extends PluginSettingTab {
 			this.plugin.settings.ignoredFolders.forEach((element, index) => {
 				new Setting(containerEl)
 					.setName(element)
-					.setClass('inner-setting')
-					.addButton(button => button
-						.setButtonText('Remove')
+					.setClass('log-keeper-setting-inner')
+					.addExtraButton(extraButton => extraButton
+						.setIcon('cross')
+						.setTooltip('Delete')
 						.onClick(async () => {
 							this.plugin.settings.ignoredFolders.splice(index, 1)
 							await this.plugin.saveSettings()
 							this.display()
 						})
-				)
-		})
+					)
+			})
 	}
 
 	hide(): void {

--- a/styles.css
+++ b/styles.css
@@ -1,27 +1,16 @@
-:disabled {
-    opacity: 0.5; /* Makes the element appear faded */
-    pointer-events: none; /* Prevents interaction */
-    cursor: not-allowed; /* Changes the cursor to indicate it's disabled */
-}
-
-.inner-setting {
-    background-color: var(--background-secondary);
-    border-top: none;
-    margin: auto 10px;
-    padding: 5px 10px;
-}
-
-.inner-setting:nth-child(2n) {
-    background-color: var(--background-primary);
-    border-top: none;
-    margin: auto 10px;
-    padding: 5px 10px;
-}
-
-.inner-setting > .setting-item-info > .setting-item-name {
-    color: var(--interactive-accent);
-}
-
 .query-highlight {
     background-color: rgba(252, 252, 0, 0.2);
+}
+
+/* 'is-disabled' class is added to elements who have had 'setDisabled()' set to 'true'. */
+/* Target only child elements of the 'log-keeper-setting' to prevent the parent style from being affected. */
+.log-keeper-setting.is-disabled > * {
+	opacity: 0.5;
+	pointer-events: none;
+	cursor: not-allowed;
+}
+
+/* Elements that sit indented to the main setting above them are marked with the 'log-keeper-setting-inner' class. */
+.log-keeper-setting-inner {
+	padding: 5px 10px;
 }


### PR DESCRIPTION
…disabled' Override in Favour of Plugin-Specific Class

To prevent conflicts with Obsidian and other plugins, change the names of classes to be more unique by prefixing them with the name of the plugin. Another conflict includes the use of the ':disabled' pseudo class. Change it to use the 'setDisabled' method in Obsidian API. This makes it much easier to control the style of disabled elements. Make the style of settings follow the default style of Obsidian. Refactor 'settings.ts' so that all settings have a style for eaiser control of styling in the future. Replace buttons with icon buttons with 'cross' symbol for simpler design.